### PR TITLE
Fixing issues with concurrent reads and writes + redirects to S3 pre-signed URLs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:1.18
+FROM mcr.microsoft.com/devcontainers/go:1.18
 ENV EDITOR=vim
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,31 @@
 {
     "build": {
-        "dockerfile": "Dockerfile",
+        "dockerfile": "Dockerfile"
     },
-    "extensions": [
-        "eamodio.gitlens",
-        "golang.Go",
-        "ms-python.python",
-        "ms-python.vscode-pylance",
-        "GitHub.copilot",
-        "mutantdino.resourcemonitor"
-    ],
-    "settings": {
-        "resmon.show.battery": false,
-        "resmon.show.cpufreq": false
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "eamodio.gitlens",
+                "golang.Go",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "GitHub.copilot",
+                "mutantdino.resourcemonitor"
+            ],
+            "settings": {
+                "resmon.show.battery": false,
+                "resmon.show.cpufreq": false
+            }
+        }
     },
     "mounts": [
-        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/,target=/root/.aws,type=bind,consistency=cached"
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws/,target=/home/vscode/.aws,type=bind,consistency=cached"
     ],
     "remoteEnv": {
         "AWS_DEFAULT_REGION": "ap-southeast-2",
         "AWS_PROFILE": "sktansandbox",
         "CODEARTIFACT_DOMAIN": "sktansandbox",
-        "CODEARTIFACT_REPO": "sandbox",
+        "CODEARTIFACT_REPO": "sandbox"
     },
     "features": {
         // Used build and deploy docker containers
@@ -33,7 +37,7 @@
         "aws-cli": "latest",
         // Testing out the proxy mechanism and for deploying via CDK
         "python": {
-            "version": "lts",
+            "version": "lts"
         },
         "node": {
             "version": "lts",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,4 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.11

--- a/src/tools/aws.go
+++ b/src/tools/aws.go
@@ -94,11 +94,11 @@ func CheckReauth() {
 	for {
 		timeSince := time.Since(CodeArtifactAuthInfo.LastAuth).Minutes()
 		// Panic and shut down the proxy if we couldn't reauthenticate within the 15 minute window for some reason.
-		if timeSince > float64(5) {
+		if timeSince > float64(60) {
 			log.Panic("Was unable to re-authenticate prior to our token expiring, shutting down proxty...")
 		}
 
-		if CodeArtifactAuthInfo.AuthorizationToken == "" || timeSince > float64(1) {
+		if CodeArtifactAuthInfo.AuthorizationToken == "" || timeSince > float64(45) {
 			log.Printf("%f minutes until the CodeArtifact token expires, attempting a reauth.", 60-timeSince)
 			Authenticate()
 		}


### PR DESCRIPTION
This should resolve issues #5 and #4 where the following issues were observed:

- concurrent reads and writes to the `originalUrlResolver` map was causing crashes
- Redirects to S3 pre-signed URLs to download packages were being modified instead of just requests targeting the codeartifact service