### PR TITLE
Allow selection of listen port

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Configuration is done via Environment Variables:
 | CODEARTIFACT_DOMAIN  | Yes        | Your CodeArtifact Domain (e.g. sktansandbox) |
 | CODEARTIFACT_TYPE    | No         | Use one of the following: pypi, npm, maven, nuget |
 | CODEARTIFACT_OWNER   | No         | The AWS Account Id of the CodeArtifact Owner (if it's your own account, it can be empty) |
+| LISTEN_PORT          | No         | Port on which the proxy should listen.  Defaults to 8080 |
 
 By default, the proxy will choose to use the Pypi as it's type.
 

--- a/src/tools/proxy.go
+++ b/src/tools/proxy.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -125,13 +126,23 @@ func ProxyInit() {
 		panic(err)
 	}
 
+	// Get port from LISTEN_PORT environment variable. If not set, default to 8080.
+	port := getEnv("LISTEN_PORT", "8080")
+
 	proxy := httputil.NewSingleHostReverseProxy(remote)
 
 	proxy.ModifyResponse = ProxyResponseHandler()
 
 	http.HandleFunc("/", ProxyRequestHandler(proxy))
-	err = http.ListenAndServe(":8080", nil)
+	err = http.ListenAndServe(":"+port, nil)
 	if err != nil {
 		panic(err)
 	}
+}
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }


### PR DESCRIPTION
TL;DR - This feels like a useful enhancement.

The long story is that I'm trying to use two instances of the proxy in one Fargate task as sidecars to an NGINX proxy that provides IDE-friendly authentication and authorization.  Since they're running in Fargate, they must use awsvpc network mode which requires both HostPort and ContainerPort to be the same.  This won't work unless I can run the two aws-codeartifact-proxy instances with different ports.

