### PR TITLE
Remove NuGet from list of support repository types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Although I haven't been able to test them all, the proxy should support the foll
 | Pypi            | Yes    | https://artifacts.example.com/simple/ |
 | NPM             | Yes    | https://artifacts.example.com/        |
 | Maven           | No     | https://artifacts.example.com/        |
-| Nuget           | No     | https://artifacts.example.com/        |
 
 Currently we only support choosing a single repository at launch, athough maybe in the future I will look at automatically figure out which repository to use based on the useragent. This should simplify setup.
 
@@ -40,7 +39,7 @@ Configuration is done via Environment Variables:
 | --------------------  | ---------- | ----------------------- |
 | `CODEARTIFACT_REPO`   | Yes        | Your CodeArtifact Repository Name (e.g. sandbox) |
 | `CODEARTIFACT_DOMAIN` | Yes        | Your CodeArtifact Domain (e.g. sktansandbox) |
-| `CODEARTIFACT_TYPE`   | No         | Use one of the following: pypi, npm, maven, nuget |
+| `CODEARTIFACT_TYPE`   | No         | Use one of the following: pypi, npm, maven |
 | `CODEARTIFACT_OWNER`  | No         | The AWS Account ID of the CodeArtifact Owner (if it's your own account, it can be empty) |
 | `LISTEN_PORT`         | No         | Port on which the proxy should listen.  Defaults to 8080 |
 


### PR DESCRIPTION
[My comment](https://github.com/sktan/aws-codeartifact-proxy/issues/3#issuecomment-1529919047) on <https://github.com/sktan/aws-codeartifact-proxy/issues/3> has details about why NuGet proxying currently does not work:

> I can also confirm that this project does not work for NuGet. As I understand it this is because unlike e.g. npm or pip, NuGet uses a handshake protocol for authentication rather than just plain HTTP auth. To be able to proxy NuGet packages from an upstream repository that requires authentication, one would need the proxy server to implement some (if not all) of NuGet's client-side authentication flow.
>
> Here are some relevant resources describing how NuGet auth works:
>
> - https://learn.microsoft.com/en-us/nuget/consume-packages/consuming-packages-authenticated-feeds
> - https://learn.microsoft.com/en-us/nuget/reference/extensibility/nuget-cross-platform-plugins#plugin-installation-and-discovery
> - https://docs.aws.amazon.com/codeartifact/latest/ug/nuget-cli.html
