### PR TITLE
Add optional health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Configuration is done via Environment Variables:
 | `CODEARTIFACT_TYPE`   | No         | Use one of the following: pypi, npm, maven |
 | `CODEARTIFACT_OWNER`  | No         | The AWS Account ID of the CodeArtifact Owner (if it's your own account, it can be empty) |
 | `LISTEN_PORT`         | No         | Port on which the proxy should listen.  Defaults to 8080 |
+| `HEALTHCHECK_PATH`    | No         | Enables a health check endpoint on the given path (e.g. `/actuator/health`) instead of proxying it. Unset by default, which disables the health check entirely |
 
 By default, the proxy will choose to use the Pypi as its type.
 
@@ -52,6 +53,27 @@ Once you have started the proxy with valid AWS credentials (this uses the [defau
 2022/04/03 04:41:53 Authorization successful
 2022/04/03 04:41:53 Requests will now be proxied to https://sktansandbox-1234567890.d.codeartifact.ap-southeast-2.amazonaws.com/pypi/sandbox/
 ```
+
+### Health Check
+
+Setting the `HEALTHCHECK_PATH` environment variable enables a lightweight health
+check on that path which does **not** proxy to CodeArtifact. It returns `200 OK`
+when the proxy holds a valid (unexpired) CodeArtifact authorization token, and
+`503 Service Unavailable` otherwise. This makes it suitable for load balancer /
+container orchestrator health probes.
+
+```
+$ HEALTHCHECK_PATH=/actuator/health ... # start the proxy
+$ curl -i http://localhost:8080/actuator/health
+HTTP/1.1 200 OK
+...
+
+OK
+```
+
+When `HEALTHCHECK_PATH` is unset the health check is disabled and all requests
+are proxied. While enabled, all other requests (and any non-GET request to the
+health path) are proxied to CodeArtifact as normal.
 
 ### Docker Examples
 

--- a/src/tools/aws.go
+++ b/src/tools/aws.go
@@ -20,6 +20,20 @@ type CodeArtifactAuthInfoStruct struct {
 
 var CodeArtifactAuthInfo = &CodeArtifactAuthInfoStruct{}
 
+// IsTokenValid reports whether we currently hold a CodeArtifact authorization
+// token that has not yet expired. Tokens are requested with a 3600 second (60
+// minute) duration in Authenticate.
+func (c *CodeArtifactAuthInfoStruct) IsTokenValid() bool {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if c.AuthorizationToken == "" {
+		return false
+	}
+
+	return time.Since(c.LastAuth).Minutes() < 60
+}
+
 // Authenticate performs the authentication against CodeArtifact and caches the credentials
 func Authenticate() {
 	log.Printf("Authenticating against CodeArtifact")

--- a/src/tools/proxy.go
+++ b/src/tools/proxy.go
@@ -124,6 +124,20 @@ func ProxyResponseHandler() func(*http.Response) error {
 
 }
 
+// HealthCheckHandler responds to health probes without proxying to
+// CodeArtifact. It returns 200 OK when a valid authorization token is held and
+// 503 Service Unavailable otherwise, so orchestrators can tell when the proxy
+// is unable to serve requests.
+func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	if CodeArtifactAuthInfo.IsTokenValid() {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "OK")
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintln(w, "CodeArtifact authorization token is not valid")
+	}
+}
+
 // ProxyInit initialises the CodeArtifact proxy and starts the HTTP listener
 func ProxyInit() {
 	remote, err := url.Parse(CodeArtifactAuthInfo.Url)
@@ -138,7 +152,25 @@ func ProxyInit() {
 
 	proxy.ModifyResponse = ProxyResponseHandler()
 
-	http.HandleFunc("/", ProxyRequestHandler(proxy))
+	proxyHandler := ProxyRequestHandler(proxy)
+
+	// The health check endpoint is opt-in: it is only enabled when
+	// HEALTHCHECK_PATH is set (e.g. /actuator/health). When enabled, a GET on
+	// that path is served as a health check rather than being proxied. All
+	// other requests (including non-GET requests to the health path) are
+	// proxied as usual.
+	if healthPath, ok := os.LookupEnv("HEALTHCHECK_PATH"); ok && healthPath != "" {
+		log.Printf("Health check enabled on GET %s", healthPath)
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == healthPath && r.Method == http.MethodGet {
+				HealthCheckHandler(w, r)
+				return
+			}
+			proxyHandler(w, r)
+		})
+	} else {
+		http.HandleFunc("/", proxyHandler)
+	}
 	err = http.ListenAndServe(":"+port, nil)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Hi.

We are using this container in an AWS EKS cluster, and without the ability to register a "healthcheck" probe, the ELB wont see the container as healthy.  I've added an *optional* heathcheck here, where if `HEALTHCHECK_PATH` is set in the environment, then that specific path will respond with a 200 Ok response if the container appears healthy.   I've just done a basic heuristic here checking if the token was refreshed recently to determine if its healthy or not.

Open to suggestions to improve this, but this made it usable behind a loadbalancer that requires a healthcheck (e.g. ELB).